### PR TITLE
fix: harden security with URL validation and tighter CSP

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "Cushion"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "block",
  "cocoa",
@@ -23,6 +23,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tauri-winrt-notification",
  "tokio",
+ "url",
  "urlencoding",
  "uuid",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+url = "2"
 tokio = { version = "1", features = ["time"] }
 raw-window-handle = "0.6"
 urlencoding = "2"

--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -23,6 +23,18 @@ pub fn get_user_agent(app: tauri::AppHandle) -> String {
 #[tauri::command]
 pub async fn open_url(app: tauri::AppHandle, url: String) -> Result<(), String> {
     use tauri_plugin_opener::OpenerExt;
-    app.opener().open_url(&url, None::<&str>).map_err(|e| e.to_string())?;
+
+    // Parse and validate URL
+    let parsed = url::Url::parse(&url).map_err(|e| format!("Invalid URL: {}", e))?;
+
+    // Only allow safe protocols
+    match parsed.scheme() {
+        "http" | "https" | "mailto" => {}
+        scheme => return Err(format!("Protocol '{}' not allowed", scheme)),
+    }
+
+    app.opener()
+        .open_url(&url, None::<&str>)
+        .map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "macOSPrivateApi": true,
     "windows": [],
     "security": {
-      "csp": "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:; connect-src 'self' ipc: http: https: ws: wss: data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' data:; img-src 'self' data: https: http: blob:; font-src 'self' data: https: http:; worker-src 'self' blob:; child-src 'self' blob:;",
-      "dangerousDisableAssetCspModification": true,
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' *.youtube.com *.twitter.com va.vercel-scripts.com *.supercut.video; style-src 'self' 'unsafe-inline' *.googleapis.com; connect-src 'self' https://app.cushion.so https://*.cushion.so wss://app.cushion.so wss://*.cushion.so ipc: http://localhost:* ws://localhost:* https://*.posthog.com https://*.vercel-storage.com https://*.uploadthing.com https://*.supercut.video; img-src 'self' https: data: blob:; font-src 'self' data: *.googleapis.com *.gstatic.com unpkg.com; media-src 'self' https: blob:; worker-src 'self' blob:; child-src 'self' blob: *.youtube.com *.google.com *.twitter.com *.loom.com *.figma.com *.supercut.video; frame-src *.youtube.com *.twitter.com *.loom.com *.figma.com *.vimeo.com *.supercut.video;",
+      "dangerousDisableAssetCspModification": false,
       "capabilities": [
         {
           "identifier": "default",


### PR DESCRIPTION
## Summary
- Tighten Content Security Policy to match web app config
- Add URL protocol validation to `open_url` command (http/https/mailto only)
- Validate deep link schemes before emitting (cushion/cushion-dev only)
- Validate notification URLs before emitting as deep links

## Changes
- `tauri.conf.json`: Stricter CSP, set `dangerousDisableAssetCspModification: false`
- `commands/system.rs`: Reject dangerous protocols like `file://`, `javascript:`
- `lib.rs`: Only emit deep links with valid schemes
- `notifications/mod.rs`: Validate notification URLs before emitting
- `Cargo.toml`: Add `url` crate for URL parsing

## Test plan
- [x] Build compiles successfully
- [ ] Test external links open in browser (https, mailto)
- [ ] Test deep links work (cushion://)
- [ ] Test notifications navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)